### PR TITLE
Remove Glados TTS from default service deployment

### DIFF
--- a/neon_diana_utils/helm_charts/diana-backend/Chart.yaml
+++ b/neon_diana_utils/helm_charts/diana-backend/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -32,7 +32,7 @@ dependencies:
     version: 11.13.0
     repository: https://charts.bitnami.com/bitnami
   - name: diana-http
-    version: 0.0.1
+    version: 0.0.2
     repository: file://../http-services
   - name: diana-mq
     version: 0.0.4

--- a/neon_diana_utils/helm_charts/http-services/Chart.yaml
+++ b/neon_diana_utils/helm_charts/http-services/Chart.yaml
@@ -14,10 +14,10 @@ dependencies:
     alias: tts-coqui
     version: *chart_version
     repository: file://charts/tts-coqui
-  - name: tts-glados
-    alias: tts-glados
-    version: *chart_version
-    repository: file://charts/tts-glados
+#  - name: tts-glados
+#    alias: tts-glados
+#    version: *chart_version
+#    repository: file://charts/tts-glados
   - name: tts-larynx
     alias: tts-larynx
     version: *chart_version

--- a/neon_diana_utils/helm_charts/http-services/Chart.yaml
+++ b/neon_diana_utils/helm_charts/http-services/Chart.yaml
@@ -3,38 +3,38 @@ name: diana-http
 description: Deploy DIANA HTTP Services
 
 type: application
-version: &chart_version 0.0.1
+version: 0.0.2
 appVersion: "1.0.1a5"
 dependencies:
   - name: libretranslate
     alias: libretranslate
-    version: *chart_version
+    version: 0.0.1
     repository: file://charts/libretranslate
   - name: tts-coqui
     alias: tts-coqui
-    version: *chart_version
+    version: 0.0.1
     repository: file://charts/tts-coqui
 #  - name: tts-glados
 #    alias: tts-glados
-#    version: *chart_version
+#    version: 0.0.1
 #    repository: file://charts/tts-glados
   - name: tts-larynx
     alias: tts-larynx
-    version: *chart_version
+    version: 0.0.1
     repository: file://charts/tts-larynx
   - name: tts-ljspeech
     alias: tts-ljspeech
-    version: *chart_version
+    version: 0.0.1
     repository: file://charts/tts-ljspeech
   - name: tts-mozilla
     alias: tts-mozilla
-    version: *chart_version
+    version: 0.0.1
     repository: file://charts/tts-mozilla
   - name: tts-nancy
     alias: tts-nancy
-    version: *chart_version
+    version: 0.0.1
     repository: file://charts/tts-nancy
   - name: ww-snowboy
     alias: ww-snowboy
-    version: *chart_version
+    version: 0.0.1
     repository: file://charts/ww-snowboy

--- a/neon_diana_utils/helm_charts/http-services/values.yaml
+++ b/neon_diana_utils/helm_charts/http-services/values.yaml
@@ -12,11 +12,11 @@ tts-coqui:
   ingress:
     enabled: False
 #  image.tag:
-tts-glados:
-  subdomain: &host_glados glados
-  servicePort: *default_port
-  ingress:
-    enabled: False
+#tts-glados:
+#  subdomain: &host_glados glados
+#  servicePort: *default_port
+#  ingress:
+#    enabled: False
 #  image.tag:
 tts-larynx:
   subdomain: &host_larynx larynx
@@ -61,9 +61,9 @@ ingress:
     - host: *host_coqui
       serviceName: tts-coqui
       servicePort: *default_port
-    - host: *host_glados
-      serviceName: tts-glados
-      servicePort: *default_port
+#    - host: *host_glados
+#      serviceName: tts-glados
+#      servicePort: *default_port
     - host: *host_larynx
       serviceName: tts-larynx
       servicePort: *default_port


### PR DESCRIPTION
# Description
Remove Glados TTS container since default model was broken by https://github.com/R2D2FISH/glados-tts/commit/018126d4d6c64d99f96203f6fe25b51fc90ab64e


# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->