### PR TITLE
Fix missing package_data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from setuptools import setup, find_packages
-from os import getenv, path
+from os import getenv, path, walk
 
 BASE_PATH = path.abspath(path.dirname(__file__))
 
@@ -61,6 +61,21 @@ with open(path.join(BASE_PATH, "neon_diana_utils",
             else:
                 version = line.split("'")[1]
 
+
+def find_resource_files():
+    resource_base_dirs = ("docker", "helm_charts", "templates")
+    base_dir = path.join(BASE_PATH, "neon_diana_utils")
+    package_data = []
+    for res in resource_base_dirs:
+        if path.isdir(path.join(base_dir, res)):
+            for (directory, _, files) in walk(path.join(base_dir, res)):
+                if files:
+                    package_data.append(
+                        path.join(directory.replace(BASE_PATH, "").lstrip('/'),
+                                  '*'))
+    return package_data
+
+
 setup(
     name='neon-diana-utils',
     version=version,
@@ -72,8 +87,7 @@ setup(
     author_email='developers@neon.ai',
     license='BSD-3-Clause',
     packages=find_packages(),
-    package_data={'neon_diana_utils': ['templates/**', 'helm_charts/**']
-                  },
+    package_data={'neon_diana_utils': find_resource_files()},
     include_package_data=True,
     install_requires=get_requirements("requirements.txt"),
     zip_safe=True,

--- a/setup.py
+++ b/setup.py
@@ -63,15 +63,15 @@ with open(path.join(BASE_PATH, "neon_diana_utils",
 
 
 def find_resource_files():
-    resource_base_dirs = ("neon_diana_utils/docker",
-                          "neon_diana_utils/templates")
+    base_path = path.join(BASE_PATH, "neon_diana_utils")
+    resource_base_dirs = ("docker", "templates")
     package_data = []
     for res in resource_base_dirs:
-        if path.isdir(path.join(BASE_PATH, res)):
-            for (directory, _, files) in walk(path.join(BASE_PATH, res)):
+        if path.isdir(path.join(base_path, res)):
+            for (directory, _, files) in walk(path.join(base_path, res)):
                 if files:
                     package_data.append(
-                        path.join(directory.replace(BASE_PATH, "").lstrip('/'),
+                        path.join(directory.replace(base_path, "").lstrip('/'),
                                   '*'))
     return package_data
 

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
     author_email='developers@neon.ai',
     license='BSD-3-Clause',
     packages=find_packages(),
-    package_data={'neon_diana_utils': ['templates/*', 'helm_charts/**']
+    package_data={'neon_diana_utils': ['templates/**', 'helm_charts/**']
                   },
     include_package_data=True,
     install_requires=get_requirements("requirements.txt"),

--- a/setup.py
+++ b/setup.py
@@ -63,12 +63,12 @@ with open(path.join(BASE_PATH, "neon_diana_utils",
 
 
 def find_resource_files():
-    resource_base_dirs = ("docker", "helm_charts", "templates")
-    base_dir = path.join(BASE_PATH, "neon_diana_utils")
+    resource_base_dirs = ("neon_diana_utils/docker",
+                          "neon_diana_utils/templates")
     package_data = []
     for res in resource_base_dirs:
-        if path.isdir(path.join(base_dir, res)):
-            for (directory, _, files) in walk(path.join(base_dir, res)):
+        if path.isdir(path.join(BASE_PATH, res)):
+            for (directory, _, files) in walk(path.join(BASE_PATH, res)):
                 if files:
                     package_data.append(
                         path.join(directory.replace(BASE_PATH, "").lstrip('/'),


### PR DESCRIPTION
# Description
`templates` includes subdirectories that should be included with installation
Recycled method from skills to include `docker` and `templates` directories as package data

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->