### PR TITLE
Update Neon Core to use namespaced backend resources

### DIFF
--- a/neon_diana_utils/configuration.py
+++ b/neon_diana_utils/configuration.py
@@ -529,7 +529,12 @@ def configure_neon_core(mq_user: str = None,
             "gui": {"server_path": "/xdg/data/neon/gui_files"},
             "ready_settings": ["skills", "voice", "audio", "gui_service"],
             "listener": {"enable_voice_loop": False},
-            "stt": {"fallback_module": None},
+            "stt": {"module": "neon-stt-plugin-nemo-remote",
+                    "neon-stt-plugin-nemo-remote": {
+                        "url": "http://backend-nemo:4430"}},
+            "tts": {"module": "neon-tts-plugin-coqui-remote",
+                    "neon-tts-plugin-coqui-remote": {
+                        "url": "http://backend-coqui:4430"}},
             "skills": {"blacklisted_skills": [
                 "skill-local_music.neongeckocom",
                 "skill-device_controls.neongeckocom",


### PR DESCRIPTION
# Description
Update default neon-core config to use remote modules configured to namespaced backend services
This prevents loading multiple STT/TTS models in the same namespace by having core services use existing endpoints
Using namespaced references ensures Neon Core will always work with normal deployments

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->