### PR TITLE
Update Klat deployment to include more subdomain routing options

### DIFF
--- a/neon_diana_utils/configuration.py
+++ b/neon_diana_utils/configuration.py
@@ -696,6 +696,10 @@ def configure_klat_chat(external_url: str = None,
         confirmed = click.confirm(f"Is '{api_url}' correct?")
     api_subdomain = api_url.split('://', 1)[1].split('.', 1)[0]
 
+    forward_www = False
+    if subdomain != "www":
+        forward_www = click.prompt(f"Route www.{domain} traffic to Klat?")
+
     # Get Libretranslate HTTP API URL
     libretranslate_url = "https://libretranslate.2022.us"
     confirmed = False
@@ -790,6 +794,11 @@ def configure_klat_chat(external_url: str = None,
             {'host': api_subdomain, 'serviceName': 'klat-chat-server',
              'servicePort': 8010}
         ]
+        if forward_www:
+            helm_values['klat']['ingress']['rules'].append({
+                {'host': 'www', 'serviceName': 'klat-chat-client',
+                 'servicePort': 8001}
+            })
         with open(join(output_path, "klat-chat", "values.yaml"), 'w') as f:
             yaml.safe_dump(helm_values, f)
     else:

--- a/neon_diana_utils/helm_charts/klat/klat-chat/Chart.yaml
+++ b/neon_diana_utils/helm_charts/klat/klat-chat/Chart.yaml
@@ -3,5 +3,5 @@ name: klat-chat
 description: Deploy Klat Services
 
 type: application
-version: 0.0.4
+version: 0.0.5
 appVersion: "1.0.1a13"

--- a/neon_diana_utils/helm_charts/klat/klat-chat/templates/ingress.yaml
+++ b/neon_diana_utils/helm_charts/klat/klat-chat/templates/ingress.yaml
@@ -13,17 +13,30 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: {{ .Values.ingress.ingressClassName }}
     cert-manager.io/issuer: {{ .Values.ingress.certIssuer }}
+    nginx.ingress.kubernetes.io/from-to-www-redirect: "true"
 spec:
   tls:
     - secretName: {{ .Values.ingress.tlsSecretName }}
       hosts:
         {{- range .Values.ingress.rules }}
+        {{- if eq .host "*" }}
+        - "*.{{ $.Values.domain }}"
+        {{- else if eq .host $.Values.domain }}
+        - {{ $.Values.domain}}
+        {{- else }}
         - {{ printf "%s.%s " .host $.Values.domain }}
+        {{- end }}
         {{- end }}
 
   rules:
     {{- range .Values.ingress.rules }}
+    {{- if eq .host "*" }}
+    - host: "*.{{ $.Values.domain }}"
+    {{- else if eq .host $.Values.domain }}
+    - host: {{ $.Values.domain}}
+    {{- else }}
     - host: {{ printf "%s.%s " .host $.Values.domain }}
+    {{- end }}
       http:
         paths:
           - path: /

--- a/neon_diana_utils/helm_charts/klat/klat-chat/values.yaml
+++ b/neon_diana_utils/helm_charts/klat/klat-chat/values.yaml
@@ -26,7 +26,7 @@ resources:
 ingress:
   enabled: True
   ingressClassName: nginx
-  tlsSecretName: tls-letsencrypt-prod
+  tlsSecretName: tls-letsencrypt-klat
   certIssuer: letsencrypt-private-key
   rules:
     - host: klat

--- a/neon_diana_utils/templates/klat/Chart.yaml
+++ b/neon_diana_utils/templates/klat/Chart.yaml
@@ -9,5 +9,5 @@ appVersion: "1.0.1a5"
 dependencies:
   - name: klat-chat
     alias: klat
-    version: 0.0.4
+    version: 0.0.5
     repository: https://neongeckocom.github.io/neon-diana-utils


### PR DESCRIPTION
# Description
Update klat ingress to handle root -> www forwarding
Rename default Klat TLS Secret
Add configuration prompt to configure additional `www` subdomain for Klat

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->