### PR TITLE
Adds CLI utility to update RMQ config with new users

### DIFF
--- a/neon_diana_utils/cli.py
+++ b/neon_diana_utils/cli.py
@@ -23,6 +23,7 @@
 # LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+from os.path import join
 
 import click
 
@@ -137,6 +138,13 @@ def configure_mq_backend(username, password, output_path):
 def make_rmq_config(username, password, output_file):
     from neon_diana_utils.configuration import generate_rmq_config
     generate_rmq_config(username, password, output_file)
+
+
+@neon_diana_cli.command(help="Update RabbitMQ definitions")
+@click.argument("config_path", default=None, required=False)
+def update_rmq_config(config_path):
+    from neon_diana_utils.configuration import update_rmq_config
+    update_rmq_config(join(config_path, "rabbitmq.json"))
 
 
 @neon_diana_cli.command(help="Generate a configuration file with access keys")

--- a/neon_diana_utils/configuration.py
+++ b/neon_diana_utils/configuration.py
@@ -337,7 +337,7 @@ def update_rmq_config(config_file: str = None) -> str:
     with open(config_file) as f:
         real_config = json.load(f)
     new_config = generate_rmq_config("", "")
-    existing_users = (user['name'] for user in real_config['users'])
+    existing_users = [user['name'] for user in real_config['users']]
     for user in new_config['users']:
         if user['name'] in existing_users:
             continue

--- a/tests/test_diana_utils.py
+++ b/tests/test_diana_utils.py
@@ -110,6 +110,10 @@ class TestConfiguration(unittest.TestCase):
         for user in old_config['users']:
             self.assertIn(user, new_config['users'])
 
+        # Ensure no duplicated users
+        for user in new_config['users']:
+            self.assertEqual(len([u for u in new_config['users']
+                                  if u['name'] == user['name']]), 1, user)
         os.remove(test_file)
         shutil.move(f"{test_file}.old", test_file)
 
@@ -129,6 +133,12 @@ class TestConfiguration(unittest.TestCase):
         self.assertEqual(set(config.keys()), {'users', 'vhosts', 'permissions'})
         for user in config['users']:
             self.assertEqual(set(user.keys()), {'name', 'password', 'tags'})
+
+        # Ensure no duplicate users
+        for user in config['users']:
+            self.assertEqual(len([u for u in config['users']
+                                  if u['name'] == user['name']]), 1, user)
+
         for vhost in config['vhosts']:
             self.assertEqual(set(vhost.keys()), {'name'})
             self.assertTrue(vhost['name'].startswith('/'))


### PR DESCRIPTION
# Description
Adds `update-rmq-config` CLI entrypoint
Fixes bug in RMQ config update that allowed for duplicated entries
Adds unit tests to test for duplicated users

# Issues
Relates to #65

# Other Notes
The `update_rmq_config` method is currently used internally, but this adds a CLI entrypoint so RMQ config can be updated independent of any other service configs