### PR TITLE
Added /llm vhost permissions for chat observer

### DIFF
--- a/neon_diana_utils/templates/rmq_backend_config.yml
+++ b/neon_diana_utils/templates/rmq_backend_config.yml
@@ -226,3 +226,8 @@ permissions:
     configure: ".*"
     write: ".*"
     read: ".*"
+  - user: "chat_observer"
+    vhost: "/llm"
+    configure: ".*"
+    write: ".*"
+    read: ".*"


### PR DESCRIPTION
# Description
This permission is required to obtain personas state in the real time