### PR TITLE
Update memory specs in Helm charts

### DIFF
--- a/neon_diana_utils/helm_charts/klat/klat-chat/Chart.yaml
+++ b/neon_diana_utils/helm_charts/klat/klat-chat/Chart.yaml
@@ -3,5 +3,5 @@ name: klat-chat
 description: Deploy Klat Services
 
 type: application
-version: 0.0.8
+version: 0.0.9
 appVersion: "1.0.1a31"

--- a/neon_diana_utils/helm_charts/klat/klat-chat/templates/ingress.yaml
+++ b/neon_diana_utils/helm_charts/klat/klat-chat/templates/ingress.yaml
@@ -14,6 +14,7 @@ metadata:
     kubernetes.io/ingress.class: {{ .Values.ingress.ingressClassName }}
     cert-manager.io/issuer: {{ .Values.ingress.certIssuer }}
     nginx.ingress.kubernetes.io/from-to-www-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
 spec:
   tls:
     - secretName: {{ .Values.ingress.tlsSecretName }}
@@ -26,6 +27,9 @@ spec:
         {{- else }}
         - {{ printf "%s.%s " .host $.Values.domain }}
         {{- end }}
+        {{- end }}
+        {{- if .Values.redirectRoot}}
+        - {{ $.Values.domain }}
         {{- end }}
 
   rules:

--- a/neon_diana_utils/helm_charts/klat/klat-chat/values.yaml
+++ b/neon_diana_utils/helm_charts/klat/klat-chat/values.yaml
@@ -16,14 +16,14 @@ images:
     image: ghcr.io/neongeckocom/chat_server
     name: klat-chat-server
   observer:
-    image: ghcr.io/neongeckocom/klatchat_observer
+    image: ghcr.io/neongeckocom/klatchat-observer
     name: klat-chat-observer
   admin:
     image: ghcr.io/neongeckocom/pyklatchat_admin
     name: klat-chat-admin
 resources:
   requests:
-    memory: "1500Mi"
+    memory: "500Mi"
     cpu: "0.01"
 
 ingress:
@@ -31,6 +31,7 @@ ingress:
   ingressClassName: nginx
   tlsSecretName: tls-letsencrypt-klat
   certIssuer: letsencrypt-private-key
+  redirectRoot: False
   rules:
     - host: klat
       serviceName: klat-chat-client

--- a/neon_diana_utils/helm_charts/neon/core/Chart.yaml
+++ b/neon_diana_utils/helm_charts/neon/core/Chart.yaml
@@ -3,7 +3,7 @@ name: neon-core
 description: Deploy Neon Core Services
 
 type: application
-version: 0.0.9
+version: 0.0.10
 appVersion: "1.0.1a31"
 dependencies:
   - name: neon-messagebus
@@ -12,15 +12,15 @@ dependencies:
     repository: file://../neon-messagebus
   - name: neon-speech
     alias: neon-speech
-    version: 0.0.6
+    version: 0.0.7
     repository: file://../neon-speech
   - name: neon-skills
     alias: neon-skills
-    version: 0.0.7
+    version: 0.0.8
     repository: file://../neon-skills
   - name: neon-audio
     alias: neon-audio
-    version: 0.0.7
+    version: 0.0.8
     repository: file://../neon-audio
   - name: neon-enclosure
     alias: neon-enclosure

--- a/neon_diana_utils/helm_charts/neon/neon-audio/Chart.yaml
+++ b/neon_diana_utils/helm_charts/neon/neon-audio/Chart.yaml
@@ -3,7 +3,7 @@ name: neon-audio
 description: Deploy Neon Core Audio Service
 
 type: application
-version: 0.0.7
+version: 0.0.8
 appVersion: "1.0.1a31"
 
 dependencies:

--- a/neon_diana_utils/helm_charts/neon/neon-audio/values.yaml
+++ b/neon_diana_utils/helm_charts/neon/neon-audio/values.yaml
@@ -7,5 +7,5 @@ image:
   tag: dev
 resources:
   requests:
-    memory: "500Mi"
+    memory: "300Mi"
     cpu: "0.1"

--- a/neon_diana_utils/helm_charts/neon/neon-skills/Chart.yaml
+++ b/neon_diana_utils/helm_charts/neon/neon-skills/Chart.yaml
@@ -3,7 +3,7 @@ name: neon-skills
 description: Deploy Neon Core Skills Service
 
 type: application
-version: 0.0.7
+version: 0.0.8
 appVersion: "1.0.1a31"
 
 dependencies:

--- a/neon_diana_utils/helm_charts/neon/neon-skills/values.yaml
+++ b/neon_diana_utils/helm_charts/neon/neon-skills/values.yaml
@@ -7,5 +7,5 @@ image:
   tag: dev
 resources:
   requests:
-    memory: "800Mi"
+    memory: "850Mi"
     cpu: "0.1"

--- a/neon_diana_utils/helm_charts/neon/neon-speech/Chart.yaml
+++ b/neon_diana_utils/helm_charts/neon/neon-speech/Chart.yaml
@@ -3,7 +3,7 @@ name: neon-speech
 description: Deploy Neon Core Speech (Voice) Service
 
 type: application
-version: 0.0.6
+version: 0.0.7
 appVersion: "1.0.1a31"
 
 dependencies:

--- a/neon_diana_utils/helm_charts/neon/neon-speech/values.yaml
+++ b/neon_diana_utils/helm_charts/neon/neon-speech/values.yaml
@@ -7,5 +7,5 @@ image:
   tag: dev
 resources:
   requests:
-    memory: "1Gi"
+    memory: "500Mi"
     cpu: "0.1"

--- a/neon_diana_utils/templates/klat/Chart.yaml
+++ b/neon_diana_utils/templates/klat/Chart.yaml
@@ -9,5 +9,5 @@ appVersion: "1.0.1a5"
 dependencies:
   - name: klat-chat
     alias: klat
-    version: 0.0.8
+    version: 0.0.9
     repository: https://neongeckocom.github.io/neon-diana-utils

--- a/neon_diana_utils/templates/neon/Chart.yaml
+++ b/neon_diana_utils/templates/neon/Chart.yaml
@@ -9,5 +9,5 @@ appVersion: "1.0.1a5"
 dependencies:
   - name: neon-core
     alias: core
-    version: 0.0.8
+    version: 0.0.10
     repository: https://neongeckocom.github.io/neon-diana-utils


### PR DESCRIPTION
# Description
Update Klat memory requests to reflect real world usage 
Update Neon memory requests to minimal requirements when external STT/TTS services are used
Update Neon skills memory requests to include some margin for initialization which commonly fails with OOM in current deployments
Update Neon Core and Klat templates to use latest chart version

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->